### PR TITLE
Compatibility fixes

### DIFF
--- a/src/SlovakEidSignTool/CardDeviceController.cs
+++ b/src/SlovakEidSignTool/CardDeviceController.cs
@@ -32,7 +32,7 @@ namespace SlovakEidSignTool
             try
             {
                 List<ISlot> slots = this.pkcs11.GetSlotList(SlotsType.WithTokenPresent);
-                this.slot = slots.SingleOrDefault(t => string.IsNullOrEmpty(zepLabel) || string.Equals(t.GetTokenInfo().Label, zepLabel, StringComparison.Ordinal));
+                this.slot = slots.SingleOrDefault(t => string.IsNullOrEmpty(zepLabel) || string.Equals(t.GetTokenInfo().Label, zepLabel, StringComparison.OrdinalIgnoreCase));
                 if (this.slot == null)
                 {
                     this.pkcs11.Dispose();

--- a/src/SlovakEidSignTool/CardDeviceController.cs
+++ b/src/SlovakEidSignTool/CardDeviceController.cs
@@ -84,7 +84,7 @@ namespace SlovakEidSignTool
                 X509Certificate2 certificate = new X509Certificate2(ckaValue);
                 if (this.IsCertificateForSigning(certificate))
                 {
-                    IObjectHandle privateKeyhandle = this.FindPrivateKey(session, ckaId, ckaLabel);
+                    IObjectHandle privateKeyhandle = this.FindPrivateKey(session, ckaId);
                     if (privateKeyhandle == null)
                     {
                         continue;
@@ -121,14 +121,13 @@ namespace SlovakEidSignTool
             return false;
         }
 
-        private IObjectHandle FindPrivateKey(ISession session, byte[] ckaId, string ckaLabel)
+        private IObjectHandle FindPrivateKey(ISession session, byte[] ckaId)
         {
             List<IObjectAttribute> searchTemplate = new List<IObjectAttribute>()
             {
                 session.Factories.ObjectAttributeFactory.Create(CKA.CKA_CLASS, CKO.CKO_PRIVATE_KEY),
                 session.Factories.ObjectAttributeFactory.Create(CKA.CKA_TOKEN, true),
                 session.Factories.ObjectAttributeFactory.Create(CKA.CKA_ID, ckaId),
-                session.Factories.ObjectAttributeFactory.Create(CKA.CKA_LABEL, ckaLabel)
             };
 
             return session.FindAllObjects(searchTemplate).FirstOrDefault();

--- a/src/SlovakEidSignTool/Program.cs
+++ b/src/SlovakEidSignTool/Program.cs
@@ -116,6 +116,9 @@ namespace SlovakEidSignTool
                 $@"C:\Program Files (x86)\eID klient\pkcs11_{(IntPtr.Size == 4 ? "x86" : "x64")}.dll",
                 $@"C:\Program Files\eID klient\pkcs11_{(IntPtr.Size == 4 ? "x86" : "x64")}.dll",
 
+                $@"C:\Program Files (x86)\eID_klient\pkcs11_{(IntPtr.Size == 4 ? "x86" : "x64")}.dll",
+                $@"C:\Program Files\eID_klient\pkcs11_{(IntPtr.Size == 4 ? "x86" : "x64")}.dll",
+
                 $@"C:/Program Files/EAC MW klient/pkcs11_{(IntPtr.Size == 4 ? "x86" : "x64")}.dll",
                 $@"C:/Program Files (x86)/EAC MW klient/pkcs11_{(IntPtr.Size == 4 ? "x86" : "x64")}.dll",
 


### PR DESCRIPTION
Compatibility fixes for issues caused by new IDs and eID Klient versions.
- The SIG_ZEP may be stored as Sig_ZEP
- The label of the certificate (Signing Certificate) no longer matches the key label (Signing Key)
- The eID Klient app defaults to underscored path on current installs.